### PR TITLE
I think this solves the rust-analyzer problem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,8 @@
                 llvmPackages.clangUseLLVM
                 rust-bindgen
               ];
-
+              # https://discourse.nixos.org/t/rust-src-not-found-and-other-misadventures-of-developing-rust-on-nixos/11570/5
+              RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
               LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
               BINDGEN_EXTRA_CLANG_ARGS = (builtins.map (a: ''-I"${a}/include"'') [
                 # add dev libraries here (e.g. pkgs.libvmi.dev)


### PR DESCRIPTION
Hey, I saw your post on mastodon and decided to investigate.

I got here from error message -> search for "rust standard library environment variable" -> find https://github.com/rust-lang/rust-analyzer/issues/4172 -> search for "RUST_SRC_PATH" nixOS -> https://discourse.nixos.org/t/rust-src-not-found-and-other-misadventures-of-developing-rust-on-nixos/11570/5

which just requires plopping `RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";` in flake.nix, at least on my machine (nixOS, though, so I haven't tested other OSes)

I don't know much of the rust ecosystem on nix, and I'm fairly new to nix (via nixOS), but this seems to fix the rust analyzer issues for me.

I'm having other rust problems because nixOS, but if you could test this and see if it works it might be an easy fix -- it got rid of the error you were talking about.